### PR TITLE
Laravel issue video player root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![npm version](https://img.shields.io/npm/v/mirax-player.svg?logo=npm&style=flat-square&label=Latest&color=blue)](https://www.npmjs.com/package/mirax-player)
 ![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen?style=flat-square)
 ![Written](https://img.shields.io/badge/JavaScript-blue?logo=javascript&label=Written&style=flat-square&color=FDDA0D)
-[![jest tested](https://img.shields.io/badge/Jest-tested-eee.svg?logo=jest&style=flat-square&labelColor=99424f)](https://github.com/jestjs/jest)
+[![jest tested](https://img.shields.io/badge/Jest-Tested-eee.svg?logo=jest&style=flat-square&labelColor=99424f)](https://github.com/jestjs/jest)
 ![Downloads](https://img.shields.io/npm/dt/mirax-player.svg?&style=flat-square&label=Downloads&color=orange)
 [![License](https://img.shields.io/npm/l/mirax-player.svg?style=flat-square&label=License&color=green)](https://github.com/demjhonsilver/mirax-player/blob/main/LICENSE.md)
 
@@ -59,7 +59,7 @@ Frameworks / Libraries | Tested versions
 -----
 
 ## Release-notes
-Version 6.1.0
+Version 6.1.1
 
 Major Changes:
 
@@ -73,6 +73,11 @@ Minor Changes:
 - Examples for React embedding are based on named exports.
 - Adding a dependency from Aziwork.
 
+Patch Changes:
+
+ v6.1.1
+
+- The Aziwork package has been updated to version 1.0.0.
 
 ## Features
 
@@ -325,7 +330,7 @@ For Angular css:
 Player Attributes |   Functionality |Type | Required |
 ------ | -------- |  ----------- | ----------
 `player-selector` | responsiveness | any| yes
-`data-player-width` | dynamic width | integer | yes
+`data-player-width` | dynamic width | number | yes
 `data-player-float`   | dynamic alignment | string |optional
 `data-player-theme` | player color |  any | optional
 `data-player-bar`  | progress bar color | any | optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirax-player",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Mirax Player is a free video player for React, Vue, Angular, and Svelte that can embed videos from platforms like Facebook, TikTok, YouTube/Shorts, Twitter, Vimeo and Dailymotion.",
   "main": "index.js",
   "types": "mirax-player.d.ts",
@@ -29,7 +29,7 @@
     "svelte"
   ],
   "dependencies": {
-    "aziwork": "^0.0.1"
+    "aziwork": "^1.0.0"
   },
   "author": "Demjhon Silver",
   "license": "MIT",


### PR DESCRIPTION
Since Laravel and React use different ports, you can use Laravel to accept the exact root path where the video file was stored in 'public/clip.mp4:  
const loadClip = window.location.origin +'/clip.mp4'; 
then:  src={loadClip}
  